### PR TITLE
Accept references as arguments

### DIFF
--- a/pyrovider/services/provider.py
+++ b/pyrovider/services/provider.py
@@ -152,6 +152,8 @@ class ServiceProvider():
                 return self._get_conf(ref[1:-1])
             elif '$' == ref[0]:
                 return self._get_env(ref[1:-1])
+            elif '^' == ref[0]:
+                return self.importer.get_obj(ref[1:])
         elif isinstance(ref, list):
             if '$' == ref[0][0]:
                 return self._get_env(ref[0][1:], ref[1])

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.6',  # Required
+    version='0.1.7',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Adds the prefix `^` to accepts fully-qualified python names as arguments

In case you were wondering, yes: `^` was chosen as a reference to Pascal's pointers.