### PR TITLE
Fixes CVE-2017-18342

### DIFF
--- a/pyrovider/services/factories.py
+++ b/pyrovider/services/factories.py
@@ -6,11 +6,11 @@ def service_provider_from_yaml(service_conf_path: str, app_conf_path: str = None
     provider = ServiceProvider()
 
     with open(service_conf_path, 'r') as fp:
-        service_conf = yaml.load(fp.read())
+        service_conf = yaml.safe_load(fp.read())
 
     if app_conf_path is not None:
         with open(app_conf_path, 'r') as fp:
-            app_conf = yaml.load(fp.read())
+            app_conf = yaml.safe_load(fp.read())
     else:
         app_conf = None
 

--- a/pyrovider/services/tests/test_provider.py
+++ b/pyrovider/services/tests/test_provider.py
@@ -21,9 +21,9 @@ class ModelSchemataTest(unittest.TestCase):
         # Given...
         self.provider = ServiceProvider()
         with open(self.service_conf_path, 'r') as fp:
-            self.service_conf = yaml.load(fp.read())
+            self.service_conf = yaml.safe_load(fp.read())
         with open(self.app_conf_path, 'r') as fp:
-            self.app_conf = yaml.load(fp.read())
+            self.app_conf = yaml.safe_load(fp.read())
         self.provider.conf(self.service_conf, self.app_conf)
 
     def test_getting_an_instance_service(self):


### PR DESCRIPTION
Fixes issue:
```YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.```

CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-18342