### PR TITLE
Allow to initialize a parameter using a service attribute

### DIFF
--- a/pyrovider/services/provider.py
+++ b/pyrovider/services/provider.py
@@ -302,7 +302,7 @@ class ServiceProvider:
     def _get_arg(self, ref: any):
         if isinstance(ref, str):
             if '@' == ref[0]:
-                return self.get(ref[1:])
+                return self._get_service(ref[1:])
             elif '%' == ref[0] == ref[-1:]:
                 return self._get_conf(ref[1:-1])
             elif '$' == ref[0]:
@@ -318,6 +318,21 @@ class ServiceProvider:
 
         return ref # Literal
 
+    def _get_service(self, service_name: str):
+        try:
+            value = self.get(service_name)
+        
+        except Exception as e:
+            # See if we are trying to access a service's attribute
+            service_name, service_attr = service_name.rsplit(".")
+            if not service_attr:
+                raise
+
+            service = self.get(service_name)
+            value = getattr(service, service_attr)
+
+        return value
+        
     def _get_conf(self, path: str):
         parts = path.split('.')
 

--- a/pyrovider/services/provider.py
+++ b/pyrovider/services/provider.py
@@ -322,7 +322,7 @@ class ServiceProvider:
         try:
             value = self.get(service_name)
         
-        except Exception as e:
+        except UnknownServiceError as e:
             # See if we are trying to access a service's attribute
             service_name, service_attr = service_name.rsplit(".", 1)
             if not service_attr:

--- a/pyrovider/services/provider.py
+++ b/pyrovider/services/provider.py
@@ -324,7 +324,7 @@ class ServiceProvider:
         
         except Exception as e:
             # See if we are trying to access a service's attribute
-            service_name, service_attr = service_name.rsplit(".")
+            service_name, service_attr = service_name.rsplit(".", 1)
             if not service_attr:
                 raise
 
@@ -332,7 +332,7 @@ class ServiceProvider:
             value = getattr(service, service_attr)
 
         return value
-        
+
     def _get_conf(self, path: str):
         parts = path.split('.')
 

--- a/pyrovider/services/tests/test_provider.py
+++ b/pyrovider/services/tests/test_provider.py
@@ -2,8 +2,6 @@ import os
 import unittest
 import yaml
 
-from typing import Any
-
 from unittest import mock
 from pyrovider.meta.construction import Singleton
 from pyrovider.services.provider import (BadConfPathError,

--- a/pyrovider/services/tests/test_provider.py
+++ b/pyrovider/services/tests/test_provider.py
@@ -2,6 +2,8 @@ import os
 import unittest
 import yaml
 
+from typing import Any
+
 from unittest import mock
 from pyrovider.meta.construction import Singleton
 from pyrovider.services.provider import (BadConfPathError,
@@ -117,6 +119,15 @@ class ModelSchemataTest(unittest.TestCase):
         # Then...
         self.assertEqual(service_c.service_a, service_a)
 
+    def test_getting_a_service_with_arguments_resolved_by_calling_another_service(self):
+        service_a = self.provider.get('service-a')
+        service_j = self.provider.get('service-j')
+        assert service_j.password == service_a.field_1
+
+        # Accessing an invalid service attribute will fail
+        with self.assertRaises(AttributeError):
+            service_k = self.provider.get('service-k')
+
     def test_getting_unknown_service(self):
         with self.assertRaises(UnknownServiceError) as context:
             self.provider.get('service-unknown')
@@ -180,7 +191,8 @@ class ModelSchemataTest(unittest.TestCase):
 
 class MockServiceA():
 
-    pass
+    def __init__(self):
+        self.field_1 = "test"
 
 
 class MockServiceB():
@@ -241,6 +253,8 @@ class MockServiceFactoryWithoutBuild(ServiceFactory):
 
 def mock_service_instance():
     pass
+
+
 
 
 if __name__ == '__main__':

--- a/pyrovider/services/tests/test_provider/service_conf.yaml
+++ b/pyrovider/services/tests/test_provider/service_conf.yaml
@@ -55,7 +55,10 @@ service-j:
   named_arguments:
     password: '@service-a.field_1'
 
+service.other.thing:
+  instance: pyrovider.services.tests.test_provider.mock_service_instance
+
 service-k:
   class: pyrovider.services.tests.test_provider.MockServiceB
   named_arguments:
-    password: '@service-h.field_1'
+    password: '@service.other.thing.field_1'

--- a/pyrovider/services/tests/test_provider/service_conf.yaml
+++ b/pyrovider/services/tests/test_provider/service_conf.yaml
@@ -41,3 +41,21 @@ service-i:
   arguments:
     - ['@service-a', '@service-b']
     - ['@service-c', '@service-h']
+
+service-j:
+  class: pyrovider.services.tests.test_provider.MockServiceB
+  arguments:
+    - '@service-a'
+    - '%some_app.api%'
+    - [$SOME_ENV_VAR, 'Some default value.']
+    - [$OTHER_ENV_VAR, '%some_app.api.url%']
+    - 'A literal value.'
+    - $INT_ENV_VAR
+    - $BOOL_ENV_VAR
+  named_arguments:
+    password: '@service-a.field_1'
+
+service-k:
+  class: pyrovider.services.tests.test_provider.MockServiceB
+  named_arguments:
+    password: '@service-h.field_1'


### PR DESCRIPTION
When defining service parameters sometimes is useful to be able to pass a service attribute as another service parameter

Ex.
```yaml
some_service:
  class: some_module.somer_service.SomeService

other_service:
  class: other_module.other_service.OtherService
  named_arguments:
    param1: '@some_service.field_1'  # allowing accessing a service attribute
```